### PR TITLE
Allow manually adjusting rules through with props

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,14 +16,55 @@ type PropsType = {
     quotes?: string,
     highlight?: (str: string, lang: string) => string,
   },
+  rules?: {
+    block?: {
+      enable?: array,
+      disable?: array,
+    },
+    core?: {
+      enable?: array,
+      disable?: array,
+    },
+    inline?: {
+      enable?: array,
+      disable?: array,
+    },
+  },
 };
 
 const MarkdownRenderer = ({
   markdown,
   options: { preset, ...options } = {},
+  rules,
   ...props
 }: PropsType) => {
   const remarkable = new Remarkable(preset || 'default', options);
+
+  /* rule is an object used to enable/disable rules.
+    {
+      core: {
+        enable: [ 'abbr' ]
+      },
+      inline: {
+        enable: [ 'ins', 'mark' ]
+      },
+      block: {
+        disable: [ 'table', 'footnote' ]
+      }
+    }
+  */
+  if (rules) {
+    Object.keys(rules).forEach(rule => {
+      if (remarkable[rule] && remarkable[rule].ruler) {
+        Object.keys(rules[rule]).forEach(flag => {
+          if (remarkable[rule].ruler[flag]) {
+            remarkable[rule].ruler[flag](rules[rule][flag]);
+          }
+        });
+      }
+    });
+  }
+
   const html = remarkable.render(markdown);
 
   return <div {...props} dangerouslySetInnerHTML={{ __html: html }} />;


### PR DESCRIPTION
- The component will iterate through a `rules` prop object and pass the settings onto the remarkable instance.

This is using the `ruler` prop in the remarkable instance: https://github.com/jonschlinkert/remarkable#manage-rules.

Here's an example of what the object could look like:

```
{
  inline: {
    disable: ['links']
  },
  block: {
    disable: ['table']
  }
}
```
There's really not a need to "enable" attributes since they are all enabled by default unless you don't pass a preset... but the repo defaults to 'default'. Maybe we should make it to allow null?