### PR TITLE
Correct flow type errors when running npm run test:ci

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ const MarkdownRenderer = ({
   rules,
   ...props
 }: PropsType) => {
-  const remarkable = new Remarkable(preset || 'default', options);
+  const remarkable: Object = new Remarkable(preset || 'default', options);
 
   /* rule is an object used to enable/disable rules.
     {
@@ -54,11 +54,13 @@ const MarkdownRenderer = ({
     }
   */
   if (rules) {
-    Object.keys(rules).forEach(rule => {
-      if (remarkable[rule] && remarkable[rule].ruler) {
-        Object.keys(rules[rule]).forEach(flag => {
-          if (remarkable[rule].ruler[flag]) {
-            remarkable[rule].ruler[flag](rules[rule][flag]);
+    const ruleObject = rules;
+
+    Object.keys(ruleObject).forEach((ruleKey: string) => {
+      if (ruleKey && remarkable[ruleKey] && remarkable[ruleKey].ruler) {
+        Object.keys(ruleObject[ruleKey]).forEach((flagKey: string) => {
+          if (remarkable[ruleKey].ruler[flagKey]) {
+            remarkable[ruleKey].ruler[flagKey](ruleObject[ruleKey][flagKey]);
           }
         });
       }


### PR DESCRIPTION
This seems to be a commonly confused pattern. [This comment was helpful](https://github.com/facebook/flow/issues/2602#issuecomment-252550925) in determining to use a `const` to protect the iterated object.